### PR TITLE
Adds tcp_request as a property to frontend.rb

### DIFF
--- a/resources/frontend.rb
+++ b/resources/frontend.rb
@@ -4,6 +4,7 @@ property :maxconn, Integer, default: 2000
 property :default_backend, String
 property :use_backend, Array
 property :acl, Array
+preoprty :tcp_request, Array
 property :option, Array
 property :stats, Hash, default: {}
 property :extra_options, Hash
@@ -41,6 +42,8 @@ action :create do
       variables['frontend'][new_resource.name]['maxconn'] << new_resource.maxconn.to_s
       variables['frontend'][new_resource.name]['use_backend'] ||= [] unless new_resource.use_backend.nil?
       variables['frontend'][new_resource.name]['use_backend'] << new_resource.use_backend unless new_resource.use_backend.nil?
+      variables['frontend'][new_resource.name]['tcp_request'] ||= [] unless new_resource.tcp_request.nil?
+      variables['frontend'][new_resource.name]['tcp_request'] << new_resource.tcp_request unless new_resource.tcp_request.nil?
       variables['frontend'][new_resource.name]['acl'] ||= [] unless new_resource.acl.nil?
       variables['frontend'][new_resource.name]['acl'] << new_resource.acl unless new_resource.acl.nil?
       variables['frontend'][new_resource.name]['option'] ||= [] unless new_resource.option.nil?


### PR DESCRIPTION
tcp_request property and associated variables added to allow for SSL content inspection for HA Proxy front end configurations.  This allows for front end inspection over back end inspection, which is a preferred method for SSL content inspection.  This also simply provides the same resource property that is already defined in backend.rb.  I have tested this multiple times with success and found no issues with this property inclusion.

### Description

This change provides the tcp_request property to the frontend.rb recipe allowing it to be leveraged as an array for SSL content inspection configurations.

### Issues Resolved

This allows multiple tcp_request configurations to be defined without errors.  Using this in extra_options causes some issues and prevents the cookbook from passing more than the first value to the hash.  Using this as an array value as is defined in backend.rb allows for content inspection at the front end.  Front end content inspection is always preferred over back end inspection.

### Contribution Check List

- [ x] All tests pass.
- [ x] New functionality includes testing.
- [ x] New functionality has been documented in the README if applicable